### PR TITLE
Make number of dummy elements grow as needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,8 +214,19 @@
           }, 2000);
 
         });
-        
-        for (let i = 0; i < 16; i++) {
+
+        addDummyElements();
+      }
+
+      let currElements = 0;
+      function addDummyElements() {
+        const eContainer = document.getElementById('bannerContainer');
+
+        // 324 comes from discord's image being 320px wide, plus the 4px margin-left applied to .imgBanner
+        const numElements = Math.floor(window.innerWidth / 324);
+
+        // Only worry about adding new elements as page grows
+        for (; currElements < numElements; currElements++) {
           const eBanner =  document.createElement('span');
           const eimga = document.createElement('a');
           const eimg = document.createElement('img');
@@ -234,6 +245,7 @@
       }
 
       buildPage(pageTitle, parentServer, guildList); 
+      window.onresize = addDummyElements;
     </script>
   </body>
 </html>


### PR DESCRIPTION
Instead of being hard-coded to 16, the number of dummy elements will now be calculated based on the width of the page, and grow as necessary when the page is resized.

Note that elements are not destroyed, since even a very large monitor won't have too many elements and creating/destroying elements on every resize may introduce a (very minor) performance concern. This way its still fast, since at most it'll only ever create ~6 elements on most monitors, but it can still handle infinitely large monitors.